### PR TITLE
typo

### DIFF
--- a/R/filter_element.R
+++ b/R/filter_element.R
@@ -17,7 +17,7 @@ filter_element <- function(x, pattern, ...){
     
     warning(
         paste(
-            "Deprecated, use textclean::drop_elements() instead.",
+            "Deprecated, use textclean::drop_element() instead.",
             "`filter_element()` will be removed in the next version."
         ),
         call. = FALSE


### PR DESCRIPTION
Thanks for this package! It's so much handy!

This PR corrects a typo in the warning of `filter_element` function.  